### PR TITLE
increase timeout, because we're still seeing timeouts

### DIFF
--- a/lib/flip/redis_store.rb
+++ b/lib/flip/redis_store.rb
@@ -2,7 +2,7 @@ module Flip
   require 'timeout'
   class RedisStore < AbstractStore
     REDIS_HASH_KEY = 'flipv2'
-    SAFE_TIMEOUT = 0.1
+    SAFE_TIMEOUT = 0.15
 
     attr :logger
 


### PR DESCRIPTION
The 0.1 was arbitrary, I suggest 0.15 as an another arbitrary figure. 

We're still seeing some timeouts, the number is quite small, but now that we're doing 1 redis call per request rather than 30, in theory this timeout could be 3 seconds and we'd get the same worst case performance.
