### PR TITLE
Definition defaults

### DIFF
--- a/lib/flip/feature_set.rb
+++ b/lib/flip/feature_set.rb
@@ -41,7 +41,7 @@ module Flip
           strategy.on?(definition, options)
         end
       else
-        default_for(definition)
+        default_for(definition, options)
       end
     end
 
@@ -65,8 +65,24 @@ module Flip
       @strategies[klass]
     end
 
-    def default_for(definition)
-      @default.is_a?(Proc) ? @default.call(definition) : @default
+    def default_for(definition, options)
+      if definition.options.include? :default
+        default = definition.options[:default]
+      else
+        default = @default
+      end
+
+      if default.is_a? Proc
+        if default.arity == 2
+          default.call(definition, options)
+        elsif default.arity == 1
+          default.call(definition)
+        else
+          default.call
+        end
+      else
+        default
+      end
     end
 
     def definitions

--- a/lib/flip/feature_set.rb
+++ b/lib/flip/feature_set.rb
@@ -29,10 +29,9 @@ module Flip
         @strategies.select{|k,v| required_strats.include?(k)}
       else
         @strategies
-      end 
+      end
 
       on = strats.each_value.any? { |s| s.knows?(d,options) && s.on?(d, options) }
-      on ||= CustomLogicProxy.new(@strategies, d, options).on? if d.options[:fallback]
       on ||= default_for d
       on
     end
@@ -68,31 +67,5 @@ module Flip
     def strategies
       @strategies.values
     end
-
-    class CustomLogicProxy
-      def initialize(strategies, definition, options)
-        @strategies = strategies
-        @definition = definition
-        @options = options
-      end
-
-      def on?
-        instance_exec(&@definition.options[:fallback])
-      end
-
-      def method_missing(m, *args, &block)
-        nice_name = m.to_s
-        if nice_name =~ /\?$/
-          nice_name = nice_name.gsub(/\?$/,'')
-          if @strategies.has_key? nice_name
-            strat = @strategies[nice_name]
-            return strat.on?(@definition, @options)
-          end
-        end
-        super(m, args, &block)
-      end
-
-    end
-
   end
 end

--- a/spec/feature_set_spec.rb
+++ b/spec/feature_set_spec.rb
@@ -1,37 +1,18 @@
 require "spec_helper"
 
-class NullStrategy < Flip::AbstractStrategy
-  def knows?(d, options = {}); false; end
-end
-
-class TrueStrategy < Flip::AbstractStrategy
-  def knows?(d, options = {}); true; end
-  def on?(d, options = {}); true; end
-end
-
-class FalseStrategy < Flip::AbstractStrategy
-  def knows?(d, options = {}); true; end
-  def on?(d, options = {}); false; end
-end
-
 describe Flip::FeatureSet do
-  let :feature_set_with_null_strategy do
-    Flip::FeatureSet.new.tap do |s|
-      s << Flip::Definition.new(:feature)
-      s.add_strategy NullStrategy
-    end
+  class NullStrategy < Flip::AbstractStrategy
+    def knows?(d, options = {}); false; end
   end
 
-  let :feature_set_with_null_then_true_strategies do
-    feature_set_with_null_strategy.tap do |s|
-      s.add_strategy TrueStrategy
-    end
+  class TrueStrategy < Flip::AbstractStrategy
+    def knows?(d, options = {}); true; end
+    def on?(d, options = {}); true; end
   end
 
-  let :feature_set_with_null_then_false_strategies do
-    feature_set_with_null_strategy.tap do |s|
-      s.add_strategy FalseStrategy
-    end
+  class FalseStrategy < Flip::AbstractStrategy
+    def knows?(d, options = {}); true; end
+    def on?(d, options = {}); false; end
   end
 
   describe ".instance" do
@@ -50,69 +31,151 @@ describe Flip::FeatureSet do
     end
   end
 
-  describe "#default= and #on? with null strategy" do
-    subject { feature_set_with_null_strategy }
-
-    it "defaults to false" do
-      subject.on?(:feature).should be_false
-    end
-
-    it "can default to true" do
-      subject.default = true
-      subject.on?(:feature).should be_true
-    end
-
-    it "accepts a proc returning true" do
-      subject.default = proc { true }
-      subject.on?(:feature).should be_true
-    end
-
-    it "accepts a proc returning false" do
-      subject.default = proc { false }
-      subject.on?(:feature).should be_false
-    end
-  end
-
-  describe "feature set with null strategy then always-true strategy" do
-    subject { feature_set_with_null_then_true_strategies }
-
-    it "returns true due to second strategy" do
-      subject.on?(:feature).should be_true
-    end
-  end
-
-  describe "feature set with always-false strategy" do
-    subject { feature_set_with_null_then_false_strategies }
-
-    it "returns false due to second strategy" do
-      subject.on?(:feature).should be_false
-    end
-
-    context "and default true" do
-      before { subject.default = true }
-
-      it "retuns false due to second strategy" do
-        subject.on?(:feature).should be_false
-      end
-    end
-  end
-
-  describe '.has?' do
+  describe "#has?" do
     subject(:feature_set) { Flip::FeatureSet.new }
 
-    context 'has key super_sweet_feature' do
-      before do
-        feature_set << double(:key => :super_sweet_feature)
-      end
+    it "doesn't have the feature" do
+      feature_set.has?(:super_sweet_feature).should be_false
+    end
 
-      it 'should have the feature' do
+    context "with a feature with key super_sweet_feature" do
+      before { feature_set << double(:key => :super_sweet_feature) }
+
+      it "has the feature" do
         feature_set.has?(:super_sweet_feature).should be_true
       end
     end
+  end
 
-    context 'doesnt has key super_sweet_feature' do
-      it 'should have the feature' do
-        feature_set.has?(:super_sweet_feature).should be_false
+  describe "#on?" do
+    let(:definition) { Flip::Definition.new(:feature) }
+    subject(:feature_set) { Flip::FeatureSet.new }
+    before { feature_set << definition }
+
+    context "with always-false strategy" do
+      before { feature_set.add_strategy FalseStrategy }
+
+      it "returns the strategy result false" do
+        expect(feature_set.on?(:feature)).to be_false
+      end
+
+      context "with feature set default true" do
+        before { feature_set.default = true }
+
+        it "returns the strategy result false" do
+          expect(feature_set.on?(:feature)).to be_false
+        end
+      end
+
+      context "with definition default true" do
+        before { feature_set << Flip::Definition.new(:feature, :default => true) }
+
+        it "returns the strategy result false" do
+          expect(feature_set.on?(:feature)).to be_false
+        end
+      end
+    end
+
+    context "with always-true strategy" do
+      before { feature_set.add_strategy TrueStrategy }
+
+      context "and no defaults" do
+        before { feature_set << Flip::Definition.new(:feature) }
+
+        it "returns the strategy result true" do
+          expect(feature_set.on?(:feature)).to be_true
+        end
+      end
+
+      context "with feature set default false" do
+        before { feature_set << Flip::Definition.new(:feature) }
+        before { feature_set.default = false }
+
+        it "returns the strategy result true" do
+          expect(feature_set.on?(:feature)).to be_true
+        end
+      end
+
+      context "with definition default false" do
+        before { feature_set << Flip::Definition.new(:feature, :default => false) }
+
+        it "returns the strategy result true" do
+          expect(feature_set.on?(:feature)).to be_true
+        end
+      end
+    end
+
+    context "with null strategy" do
+      before { feature_set.add_strategy NullStrategy }
+
+      context "and feature set default" do
+        let(:feature_set_default) { double }
+        before { feature_set.default = feature_set_default }
+
+        it "returns the feature set default" do
+          expect(feature_set.on?(:feature)).to be(feature_set_default)
+        end
+
+        context "when default is a proc" do
+          let(:proc_result) { double }
+          let(:feature_set_default) { proc { proc_result } }
+
+          it "returns the proc result" do
+            expect(feature_set.on?(:feature)).to be(proc_result)
+          end
+
+          context "with an arity of 1" do
+            let(:definition) { Flip::Definition.new(:feature, :on => true) }
+            let(:feature_set_default) { proc { |definition| definition.options[:on] } }
+
+            it "passes the definition to the proc" do
+              expect(feature_set.on?(:feature)).to be_true
+            end
+          end
+
+          context "with an arity of 2" do
+            let(:feature_set_default) { proc { |_, options| options[:on] } }
+
+            it "passes the options to the proc" do
+              expect(feature_set.on?(:feature, :on => true)).to be_true
+            end
+          end
+        end
+
+        context "and definition default" do
+          let(:definition_default) { double }
+          let(:definition) { Flip::Definition.new(:feature, :default => definition_default) }
+
+          it "returns the definition default" do
+            expect(feature_set.on?(:feature)).to be(definition_default)
+          end
+
+          context "when default is a proc" do
+            let(:proc_result) { double }
+            let(:definition_default) { proc { proc_result } }
+
+            it "returns the proc result" do
+              expect(feature_set.on?(:feature)).to be(proc_result)
+            end
+
+            context "with an arity of 1" do
+              let(:definition) { Flip::Definition.new(:feature, :default => definition_default, :on => true) }
+              let(:definition_default) { proc { |definition| definition.options[:on] } }
+
+              it "passes the definition to the proc" do
+                expect(feature_set.on?(:feature)).to be_true
+              end
+            end
+
+            context "with an arity of 2" do
+              let(:definition_default) { proc { |_, options| options[:on] } }
+
+              it "passes the options to the proc" do
+                expect(feature_set.on?(:feature, :on => true)).to be_true
+              end
+            end
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
`FeatureSet` defaults aren't actually default at the moment. A `FeatureSet` with a default of true, then a strategy which returns false (like a feature being globally turned off) should yield a feature being "off", but at the moment this leaves the feature "on". This fixes the "on" logic to respect any strategy which "knows" whether a feature is on/off, and only if there are no strategies which know will it fall back to the default.

This also adds more resilient `Definition`-specific defaults. These will override the `FeatureSet` default for that particular feature. But a definition-specific default of true can still be overridden by a strategy which "knows" and is "off". The idea is to deprecate `DefinitionStrategy`.

This also removes the horrendously weird `CustomLogicProxy` because it isn't used and seems convoluted and unnecessary.

/cc @macosgrove @mariovisic 