### PR TITLE
Cleanup unused redis keys for performance

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,5 +3,4 @@ rvm:
   - 2.0.0
   - 1.9.3
   - jruby-19mode
-  - rbx-19mode
 sudo: false

--- a/lib/flip/redis_store.rb
+++ b/lib/flip/redis_store.rb
@@ -31,10 +31,13 @@ module Flip
       possible_combinations = existing_keys.product(existing_strategies)
       possible_prefixes = possible_combinations.map { |key, strat| "#{key}-#{strat}" }
       get_cached if @cache.empty?
-      @cache.keys.each do |key|
-        outdated = possible_prefixes.none? { |prefix| key.starts_with?(prefix) }
-        safely { @redis.hdel(REDIS_HASH_KEY, key) } if outdated
-      end
+      @cache.keys.map { |key|
+        outdated = possible_prefixes.none? { |prefix| key.start_with?(prefix) }
+        if outdated
+          safely { @redis.hdel(REDIS_HASH_KEY, key) }
+          key
+        end
+      }.compact
     end
 
     private

--- a/lib/flip/redis_store.rb
+++ b/lib/flip/redis_store.rb
@@ -25,7 +25,7 @@ module Flip
       get_cached
     end
 
-    def cleanup_unused_keys(feature_set = Flip::FeatureSet.instance)
+    def cleanup_disused_keys(feature_set = Flip::FeatureSet.instance)
       existing_keys = feature_set.definitions.map(&:key)
       existing_strategies = feature_set.strategies.map(&:name)
       possible_combinations = existing_keys.product(existing_strategies)

--- a/spec/redis_store_spec.rb
+++ b/spec/redis_store_spec.rb
@@ -55,7 +55,7 @@ describe Flip::RedisStore do
     end
   end
 
-  describe "#cleanup_unused_keys" do
+  describe "#cleanup_disused_keys" do
     before do
       expect(redis).to receive(:hgetall).with('flipv2').and_return({
         'feature1-strategy1-value' => 'true',
@@ -87,7 +87,7 @@ describe Flip::RedisStore do
     it "deletes redis entries for removed features/strategies" do
       expect(redis).to receive(:hdel).with('flipv2', 'notafeature-strategy1-value')
       expect(redis).to receive(:hdel).with('flipv2', 'feature1-notastrategy-value')
-      store.cleanup_unused_keys(feature_set)
+      store.cleanup_disused_keys(feature_set)
     end
   end
 end


### PR DESCRIPTION
Trello: https://trello.com/c/WI1Po9NH/879-performance-do-not-load-disused-feature-toggles-from-redis

Redis retains the states for features that have long been removed from the app. And they all get pulled in each request made to our app.

This will let us clean up obsolete features (i.e. removed from feature.rb) from the Market app (likely in a Rails task) and should speed things up.