### PR TITLE
Remove upper limit for ActiveSupport

### DIFF
--- a/flip.gemspec
+++ b/flip.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
 
-  s.add_dependency("activesupport", ">= 5.0", "< 6")
+  s.add_dependency("activesupport", ">= 5.0")
   s.add_dependency("i18n")
 
   s.add_development_dependency("rspec", "~> 2.5", "< 2.99")


### PR DESCRIPTION
This isn't needed and holds back testing Rails master