### PR TITLE
Remove rubyforge_project definition

### DIFF
--- a/flip.gemspec
+++ b/flip.gemspec
@@ -12,8 +12,6 @@ Gem::Specification.new do |s|
   s.summary     = %q{A feature flipper for Rails web applications.}
   s.description = %q{Declarative API for specifying features, switchable in declaration, database and cookies.}
 
-  s.rubyforge_project = "flip"
-
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }


### PR DESCRIPTION
Resolves the warning:

    NOTE: Gem::Specification#rubyforge_project= is deprecated with no replacement. It will be removed on or after 2019-12-01.
    Gem::Specification#rubyforge_project= called from /ruby/2.5.7/lib/ruby/gems/2.5.0/bundler/gems/flip-0e5b3acb39a7/flip.gemspec:15.