### PR TITLE
Make REDIS_HASH_KEY configurable in RedisStore

### DIFF
--- a/lib/flip/redis_store.rb
+++ b/lib/flip/redis_store.rb
@@ -56,7 +56,7 @@ module Flip
         begin
           yield
         rescue Redis::BaseError => e
-         logger.warn("Flip had a problem with redis: #{e}")
+          logger.warn("Flip had a problem with redis: #{e}")
           nil
         end
       end

--- a/spec/redis_store_spec.rb
+++ b/spec/redis_store_spec.rb
@@ -10,7 +10,7 @@ describe Flip::RedisStore do
 
   before do
     stub_const("Redis", Class.new)
-    stub_const("Redis::BaseError", StandardError)
+    stub_const("Redis::BaseError", RuntimeError)
     store.stub(:logger => logger)
     store.clear_cache
   end

--- a/spec/redis_store_spec.rb
+++ b/spec/redis_store_spec.rb
@@ -6,7 +6,7 @@ describe Flip::RedisStore do
   let(:redis) { double }
   let(:logger) { double(:warn => nil) }
 
-  subject(:store) { Flip::RedisStore.new(redis) }
+  subject(:store) { Flip::RedisStore.new(redis: redis) }
 
   before do
     stub_const("Redis", Class.new)
@@ -21,12 +21,31 @@ describe Flip::RedisStore do
       expect(redis).to receive(:hset).with('flipv2', 'purchase_flow-ip-global', 20)
       store.set(:purchase_flow, "ip", "global", 20)
     end
+
+    context "with a different redis hash key" do
+      subject(:store) { Flip::RedisStore.new(redis: redis, redis_hash_key: 'outage') }
+
+      it "uses the passed in key" do
+        expect(redis).to receive(:hgetall).and_return({})
+        expect(redis).to receive(:hset).with('outage', 'purchase_flow-ip-global', 20)
+        store.set(:purchase_flow, "ip", "global", 20)
+      end
+    end
   end
 
   describe "#get" do
     it "returns the expected value from redis" do
       expect(redis).to receive(:hgetall).with('flipv2').and_return({'purchase_flow-ip-global' => 'true'})
       expect(store.get(:purchase_flow,'ip','global')).to eq('true')
+    end
+
+    context "with a different redis hash key" do
+      subject(:store) { Flip::RedisStore.new(redis: redis, redis_hash_key: 'outage') }
+
+      it "uses the passed in key" do
+        expect(redis).to receive(:hgetall).with('outage').and_return({'purchase_flow-ip-global' => 'true'})
+        expect(store.get(:purchase_flow,'ip','global')).to eq('true')
+      end
     end
 
     describe "errors" do
@@ -52,6 +71,21 @@ describe Flip::RedisStore do
 
       expect(redis).to receive(:hgetall).with('flipv2').and_return({'purchase_flow-ip-global' => 20})
       expect(store.get(:purchase_flow, "ip", "global")).to eq(20)
+    end
+
+    context "with a different redis hash key" do
+      subject(:store) { Flip::RedisStore.new(redis: redis, redis_hash_key: 'outage') }
+
+      it "persists after the cache is cleared" do
+        expect(redis).to receive(:hgetall).and_return({})
+        expect(redis).to receive(:hset).with('outage','purchase_flow-ip-global',20)
+
+        store.set(:purchase_flow, "ip", "global", 20)
+        store.clear_cache
+
+        expect(redis).to receive(:hgetall).with('outage').and_return({'purchase_flow-ip-global' => 20})
+        expect(store.get(:purchase_flow, "ip", "global")).to eq(20)
+      end
     end
   end
 

--- a/spec/redis_store_spec.rb
+++ b/spec/redis_store_spec.rb
@@ -10,7 +10,7 @@ describe Flip::RedisStore do
 
   before do
     stub_const("Redis", Class.new)
-    stub_const("Redis::BaseError", StandardError.new)
+    stub_const("Redis::BaseError", StandardError)
     store.stub(:logger => logger)
     store.clear_cache
   end


### PR DESCRIPTION
In the case where 2 separate instances of RedisStore are being used, it's ideal to separate the redis storage location, otherwise the cleanup_disused_keys method can delete keys from things in the other store.