### PR TITLE
Remove hard dependency on FeatureSet

### DIFF
--- a/flip.gemspec
+++ b/flip.gemspec
@@ -21,5 +21,6 @@ Gem::Specification.new do |s|
   s.add_dependency("i18n")
 
   s.add_development_dependency("rspec", "~> 2.5", "< 2.99")
+  s.add_development_dependency("rack")
   s.add_development_dependency("rake")
 end

--- a/lib/flip/abstract_strategy.rb
+++ b/lib/flip/abstract_strategy.rb
@@ -1,5 +1,10 @@
 module Flip
   class AbstractStrategy
+    attr_reader :feature_set
+
+    def initialize(feature_set: nil)
+      @feature_set = feature_set
+    end
 
     def name
       self.class.name.split("::").last.gsub(/Strategy$/, "").underscore

--- a/lib/flip/database_strategy.rb
+++ b/lib/flip/database_strategy.rb
@@ -2,7 +2,8 @@
 module Flip
   class DatabaseStrategy < AbstractStrategy
 
-    def initialize(model_klass = Feature)
+    def initialize(feature_set: nil, model_klass: Feature)
+      super(feature_set: feature_set)
       @klass = model_klass
     end
 

--- a/lib/flip/feature_set.rb
+++ b/lib/flip/feature_set.rb
@@ -57,7 +57,7 @@ module Flip
 
     # Adds a strategy for determing feature status.
     def add_strategy(strategy)
-      strategy = strategy.new if strategy.is_a? Class
+      strategy = strategy.new(feature_set: self) if strategy.is_a? Class
       @strategies[strategy.name] = strategy
     end
 

--- a/lib/flip/middleware.rb
+++ b/lib/flip/middleware.rb
@@ -8,8 +8,9 @@ module Flip
       end
     end
 
-    def initialize(app)
+    def initialize(app, feature_set_classes: [FeatureSet])
       @app = app
+      @feature_set_classes = feature_set_classes
     end
 
     def call(env)
@@ -26,7 +27,9 @@ module Flip
     private
 
     def clear_flip_cache
-      Flip::FeatureSet.instance.data_store.clear_cache
+      @feature_set_classes.each do |feature_set_class|
+        feature_set_class.instance.data_store.clear_cache
+      end
     end
   end
 end

--- a/lib/flip/strategy_persistence.rb
+++ b/lib/flip/strategy_persistence.rb
@@ -12,8 +12,9 @@ module Flip
     end
 
     private
+
     def data_store
-      FeatureSet.instance.data_store
+      feature_set.data_store
     end
   end
 end

--- a/lib/flip/strategy_persistence.rb
+++ b/lib/flip/strategy_persistence.rb
@@ -2,8 +2,7 @@ module Flip
   module StrategyPersistence
     # active_record: id, definition_key, strategy, param_key, value
     # active_record: id, definition_key, strategy, enabled
-    # redis hset "flip-#{definition_key}-#{strategy}", param_key, value
-    # redis set "flip-#{definition_key}-#{strategy}", "enabled", true
+    # redis hset "flipv2" "#{definition_key}-#{strategy}-#{param_key}" value
     def get(definition_key, param_key)
       data_store.get(definition_key, self.name, param_key)
     end

--- a/spec/database_strategy_spec.rb
+++ b/spec/database_strategy_spec.rb
@@ -3,7 +3,7 @@ require "spec_helper"
 describe Flip::DatabaseStrategy do
 
   let(:definition) { double("definition").tap{ |d| d.stub(:key) { :one } } }
-  let(:strategy) { Flip::DatabaseStrategy.new(model_klass) }
+  let(:strategy) { Flip::DatabaseStrategy.new(model_klass: model_klass) }
   let(:model_klass) do
     Class.new do
       extend Flip::Declarable

--- a/spec/middleware_spec.rb
+++ b/spec/middleware_spec.rb
@@ -1,0 +1,24 @@
+require "spec_helper"
+require 'rack'
+
+describe Flip::Middleware do
+  let(:app_result) { double('result') }
+  let(:app) { double(call: app_result) }
+  let(:feature_set_class) { double }
+  let(:feature_set_classes) { [feature_set_class] }
+  let(:env) { { 'PATH_INFO' => '/' } }
+  subject(:middleware) { Flip::Middleware.new(app, feature_set_classes: feature_set_classes) }
+
+  before do
+    feature_set_class.stub_chain(:instance, :data_store, :clear_cache)
+  end
+
+  it "clears the cache for each feature set class on each request" do
+    data_store = double
+    expect(data_store).to receive(:clear_cache)
+    instance = double
+    expect(instance).to receive(:data_store).and_return(data_store)
+    expect(feature_set_class).to receive(:instance).and_return(instance)
+    middleware.call(env)
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,1 +1,2 @@
 require "flip"
+require "rack"


### PR DESCRIPTION
Removes the hard dependency from strategies to FeatureSet. This causes issues if there are subclasses of FeatureSet, such as `OutageTottleSet`, since the strategies used there would use the same flipv2 key for storage (due to the hard dependency on FeatureSet).

The new approach passes in feature_set to the strategy when it's added to the feature set, so that OutageToggleSet or FeatureSet have their own Redis data store.