### PR TITLE
Use GitHub Actions for CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,23 @@
+---
+name: Tests
+on: [ push, pull_request ]
+jobs:
+  test:
+    name: Test (Ruby ${{ matrix.ruby }}, Rails ${{ matrix.rails }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby: [ '2.6', '2.7' ]
+        rails: [ '5.0', '5.1', '5.2' ]
+        # exclude:
+        #   - { ruby: '2.1', rails: '5.0' }
+    env:
+      BUNDLE_GEMFILE: gemfiles/rails-${{ matrix.rails }}.gemfile
+    steps:
+      - uses: actions/checkout@v6
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+          bundler-cache: true
+      - run: bundle exec rake

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,0 @@
-language: ruby
-rvm:
-  - 2.4.0
-  - 2.3.3
-  - 2.2.6
-sudo: false

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Flip &mdash; flip your features
 ================
 
-[![Build Status](https://travis-ci.org/pda/flip.png)](https://travis-ci.org/pda/flip)
+[![Build Status](https://github.com/envato/flip/actions/workflows/test.yml/badge.svg)](https://github.com/envato/flip/actions/workflows/test.yml)
 
 **Flip** provides a declarative, layered way of enabling and disabling application functionality at run-time.
 

--- a/gemfiles/rails-5.0.gemfile
+++ b/gemfiles/rails-5.0.gemfile
@@ -1,0 +1,6 @@
+source "https://rubygems.org"
+
+gem "activesupport", "~>5.0.0"
+gem "i18n"
+
+gemspec path: "../"

--- a/gemfiles/rails-5.1.gemfile
+++ b/gemfiles/rails-5.1.gemfile
@@ -1,0 +1,6 @@
+source "https://rubygems.org"
+
+gem "activesupport", "~>5.1.0"
+gem "i18n"
+
+gemspec path: "../"

--- a/gemfiles/rails-5.2.gemfile
+++ b/gemfiles/rails-5.2.gemfile
@@ -1,0 +1,6 @@
+source "https://rubygems.org"
+
+gem "activesupport", "~>5.2.0"
+gem "i18n"
+
+gemspec path: "../"


### PR DESCRIPTION
TravisCI is dead, let's migrate the CI build to GitHub Actions.